### PR TITLE
Added a color parameter to Chilitags::draw

### DIFF
--- a/include/chilitags.hpp
+++ b/include/chilitags.hpp
@@ -119,8 +119,11 @@ int decode(const cv::Matx<unsigned char, 6, 6> &bits) const;
     \param withMargin a boolean coding whether the returned image of the tag
     should be surrounded by a white frame, ensuring that the edges of the tag
     will contrast with the background.
+
+    \param color the RGB color with which to draw the tag. Values are integers
+    within [0,255]. The darker, the better. Black is default and optimal.
  */
-cv::Mat draw(int id, int cellSize = 1, bool withMargin = false) const;
+cv::Mat draw(int id, int cellSize = 1, bool withMargin = false, cv::Scalar color = cv::Scalar(0,0,0)) const;
 
 ~Chilitags();
 

--- a/tools/creator/README.md
+++ b/tools/creator/README.md
@@ -43,7 +43,7 @@ Usage of `creator`
 
 ### Synopsis
 
-    creator tagId [zoom [margin]]
+    creator tagId [zoom [margin [red green blue]]]
 
 ### Description
 
@@ -58,6 +58,9 @@ It does not disturb the detection, as long as the outside, black border remains 
 
 *margin* is n if and only if no white rectangle should be drawn around the tag.
 Make sure to follow the design and printing guidelines then.
+
+*red green blue* are integers within [0,255] which define the color with which
+to draw the tag. The darker, the better. Black is default and optimal.
 
 ### Examples
 

--- a/tools/creator/creator.cpp
+++ b/tools/creator/creator.cpp
@@ -28,13 +28,15 @@
 int main(int argc, char **argv)
 {
     if (argc <= 1) {
-        std::cout << "Usage: " << argv[0] << " tagID [zoom [margin]]\n";
+        std::cout << "Usage: " << argv[0] << " tagID [zoom [margin [red green blue]]]\n";
         std::cout << " - tagId is the id of the tag to draw, between 0 and 1023,\n";
         std::cout << " - zoom is a non null integer indicating the length in pixel\n";
         std::cout << "   of each bit of the tag matrix (default: 1).\n";
         std::cout << " - margin is n if no white rectangle should be drawn around the tag,\n";
         std::cout << "   (make sure the black borders of the tag\n";
         std::cout << "   still contrast with where it is placed),\n";
+        std::cout << " - red, green and blue define the color with which to draw the tag.\n";
+        std::cout << "   The darker, the better. Black is default and optimal.\n";
         return 1;
     }
 
@@ -42,10 +44,9 @@ int main(int argc, char **argv)
     int tagId = std::atoi(argv[1]);
     int zoom = (argc > 2) ? std::atoi(argv[2]) : 1;
     bool noMargin = (argc > 3 && argv[3][0] == 'n');
+    cv::Scalar color = (argc > 6 ? cv::Scalar(std::atoi(argv[4]), std::atoi(argv[5]), std::atoi(argv[6])) : cv::Scalar(0,0,0));
 
-    chilitags::Chilitags chilitags;
-
-    cv::imwrite(outputFilename, chilitags.draw(tagId, zoom, !noMargin));
+    cv::imwrite(outputFilename, chilitags::Chilitags().draw(tagId, zoom, !noMargin, color));
 
     return 0;
 }


### PR DESCRIPTION
Chilitags::draw can now use another color than black... but it needs to be dark enough to contrast.

I needed this for a "side project", and maybe someone else needd it. I don't know if it is worth the API change...
