### PR TITLE
Expose the camera field of view in Chilitags3D

### DIFF
--- a/include/chilitags.hpp
+++ b/include/chilitags.hpp
@@ -492,6 +492,14 @@ const cv::Mat &getCameraMatrix()     const;
 */
 const cv::Mat &getDistortionCoeffs() const;
 
+/**
+    Returns the vertical camera field of view in degrees, based on the known
+    camera calibration.
+
+    Useful to later re-build projection matrices, for instance in OpenGL.
+*/
+float getFOV() const;
+
 ~Chilitags3D();
 
 private:

--- a/src/Chilitags3D.cpp
+++ b/src/Chilitags3D.cpp
@@ -18,6 +18,8 @@
 *   along with Chilitags.  If not, see <http://www.gnu.org/licenses/>.         *
 *******************************************************************************/
 
+#define _USE_MATH_DEFINES
+#include <cmath> // atan
 #include <chilitags.hpp>
 
 #include "Filter.hpp"
@@ -273,6 +275,10 @@ cv::Size readCalibration(const std::string &filename) {
 const cv::Mat &getCameraMatrix()     const {return mCameraMatrix;}
 const cv::Mat &getDistortionCoeffs() const{return mDistCoeffs;}
 
+float getFOV() const{
+    return 2 * atan(mCameraMatrix.at<double>(1,2)/mCameraMatrix.at<double>(0,0)) * 180.f/M_PI;
+}
+
 private:
 void computeTransformation(const std::string& name,
                            const std::vector<cv::Point3f>& objectPoints,
@@ -364,3 +370,5 @@ const cv::Mat &chilitags::Chilitags3D::getCameraMatrix()     const {
     return mImpl->getCameraMatrix();}
 const cv::Mat &chilitags::Chilitags3D::getDistortionCoeffs() const {
     return mImpl->getDistortionCoeffs();}
+float chilitags::Chilitags3D::getFOV() const {
+    return mImpl->getFOV();}


### PR DESCRIPTION
Useful in particular to rebuild projection matrices in OpenGL for instance.
