### PR TITLE
Tag config can be read from string itself as an option

### DIFF
--- a/include/chilitags.hpp
+++ b/include/chilitags.hpp
@@ -434,8 +434,10 @@ std::map<std::string, cv::Matx44d> estimate(
     \param readFromString If true, will read tag configuration directly from the
     given string. If false (default) will open the file with the given name and
     try to read the configuration from there.
+
+    \return Whether reading the configuration was successful
  */
-void readTagConfiguration(
+bool readTagConfiguration(
     const std::string &filenameOrString,
     bool omitOtherTags = false,
     bool readFromString = false);

--- a/src/Chilitags3D.cpp
+++ b/src/Chilitags3D.cpp
@@ -213,7 +213,7 @@ void setDefaultTagSize(float defaultSize){
     };
 }
 
-void read3DConfiguration(const std::string &filenameOrString, bool omitOtherTags, bool readFromString) {
+bool read3DConfiguration(const std::string &filenameOrString, bool omitOtherTags, bool readFromString) {
     mOmitOtherTags = omitOtherTags;
 
     int mode;
@@ -230,7 +230,7 @@ void read3DConfiguration(const std::string &filenameOrString, bool omitOtherTags
         }
         else
             std::cerr << "Could not open file: " << filenameOrString << std::endl;
-        return;
+        return false;
     }
 
     mId2Configuration.clear();
@@ -254,6 +254,8 @@ void read3DConfiguration(const std::string &filenameOrString, bool omitOtherTags
                 TagConfig(id, size, keep, cv::Vec3f(translation), cv::Vec3f(rotation)));
         }
     }
+
+    return true;
 }
 
 
@@ -356,8 +358,8 @@ void chilitags::Chilitags3D::setDefaultTagSize(float defaultSize){
     mImpl->setDefaultTagSize(defaultSize);
 }
 
-void chilitags::Chilitags3D::readTagConfiguration(const std::string &filenameOrString, bool omitOtherTags, bool readFromString){
-    mImpl->read3DConfiguration(filenameOrString, omitOtherTags, readFromString);
+bool chilitags::Chilitags3D::readTagConfiguration(const std::string &filenameOrString, bool omitOtherTags, bool readFromString){
+    return mImpl->read3DConfiguration(filenameOrString, omitOtherTags, readFromString);
 }
 
 void chilitags::Chilitags3D::setCalibration(


### PR DESCRIPTION
This PR enables the option of reading the tag configuration from the string instead of a file. This will allow reading tag configs in environments where regular file system access assumptions cannot be made, such as packaging the file with a `qrc`.

This PR does not break existing functionality in the user code. 
