### PR TITLE
[sample/detect-from-file] Display total time

### DIFF
--- a/samples/chilitags-cubes.svg
+++ b/samples/chilitags-cubes.svg
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 744.09448819 1052.3622047"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="chilitags-cubes.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.49497475"
+     inkscape:cx="59.904964"
+     inkscape:cy="467.94161"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g4393"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
+     inkscape:window-x="0"
+     inkscape:window-y="867"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:16.00360489px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="66.64724"
+       y="86.924637"
+       id="text4221"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4223"
+         x="66.64724"
+         y="86.924637">size: 30mm</tspan></text>
+    <g
+       id="g4393"
+       transform="matrix(0,-1,1,0,-94.208508,876.13325)">
+      <text
+         sodipodi:linespacing="125%"
+         id="text4205"
+         y="632.75092"
+         x="225.71428"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="632.75092"
+           x="225.71428"
+           id="tspan4207"
+           sodipodi:role="line">6</tspan></text>
+      <text
+         sodipodi:linespacing="125%"
+         id="text4209"
+         y="831.87946"
+         x="420.83691"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="831.87946"
+           x="420.83691"
+           id="tspan4211"
+           sodipodi:role="line">8</tspan></text>
+      <text
+         sodipodi:linespacing="125%"
+         id="text4213"
+         y="500.22562"
+         x="754.74121"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="500.22562"
+           x="754.74121"
+           id="tspan4215"
+           sodipodi:role="line">7</tspan></text>
+      <text
+         sodipodi:linespacing="125%"
+         id="text4217"
+         y="627.03662"
+         x="39.99992"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="627.03662"
+           x="39.99992"
+           id="tspan4219"
+           sodipodi:role="line">9</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="576.42853"
+         y="630.60803"
+         id="text4257"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan4259"
+           x="576.42853"
+           y="630.60803">10</tspan></text>
+      <text
+         sodipodi:linespacing="125%"
+         id="text4261"
+         y="292.03659"
+         x="573.57141"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="292.03659"
+           x="573.57141"
+           id="tspan4263"
+           sodipodi:role="line">11</tspan></text>
+      <g
+         transform="translate(-494.31889,198.57143)"
+         id="g4271"
+         style="fill:#729fcf">
+        <rect
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4195"
+           width="185.73737"
+           height="183.59543"
+           x="461.92383"
+           y="184.3681" />
+        <rect
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4265"
+           width="101.29921"
+           height="101.29921"
+           x="504.41992"
+           y="225.50793" />
+      </g>
+      <g
+         transform="translate(-308.68306,198.57143)"
+         id="g4276"
+         style="fill:#729fcf">
+        <rect
+           y="184.3681"
+           x="461.92383"
+           height="183.59543"
+           width="185.73737"
+           id="rect4278"
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           y="225.36295"
+           x="504.25562"
+           height="101.29921"
+           width="101.29921"
+           id="rect4282"
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         id="g4284"
+         transform="translate(-123.80484,198.57143)"
+         style="fill:#729fcf">
+        <rect
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4286"
+           width="185.73737"
+           height="183.59543"
+           x="461.92383"
+           y="184.3681" />
+        <rect
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4290"
+           width="101.29921"
+           height="101.29921"
+           x="504.44415"
+           y="225.40077" />
+      </g>
+      <g
+         transform="translate(61.093691,198.57143)"
+         id="g4292"
+         style="fill:#729fcf">
+        <rect
+           y="184.3681"
+           x="461.92383"
+           height="183.59543"
+           width="185.73737"
+           id="rect4294"
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           y="226.19606"
+           x="504.11313"
+           height="101.29921"
+           width="101.29921"
+           id="rect4298"
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         id="g4300"
+         transform="translate(-123.80484,14.955899)"
+         style="fill:#729fcf">
+        <rect
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4302"
+           width="185.73737"
+           height="183.59543"
+           x="461.92383"
+           y="184.3681" />
+        <rect
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4306"
+           width="101.29921"
+           height="101.29921"
+           x="504.5065"
+           y="225.59721" />
+      </g>
+      <g
+         transform="translate(-123.80484,381.42934)"
+         id="g4308"
+         style="fill:#729fcf">
+        <rect
+           y="184.3681"
+           x="461.92383"
+           height="183.59543"
+           width="185.73737"
+           id="rect4310"
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           y="225.86803"
+           x="504.57129"
+           height="101.29921"
+           width="101.29921"
+           id="rect4314"
+           style="opacity:1;fill:#729fcf;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.9992126;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:0.9992126,2.9976378;stroke-dashoffset:0"
+         d="m 336.98533,201.35137 -43.63289,37.89766 0,102.81662 43.9593,39.31645"
+         id="path4458"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4460"
+         d="m 336.98533,567.77994 -43.63289,37.89766 0,102.81662 43.9593,39.31645"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 526.36945,747.80587 43.63289,-37.89766 0,-102.81662 -43.9593,-39.31645"
+         id="path4462"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4464"
+         d="m 525.3593,380.23716 43.63289,-37.89766 0,-102.81662 -43.9593,-39.31645"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 708.51231,565.66302 43.63289,-37.89766 0,-102.81662 -43.9593,-39.31645"
+         id="path4466"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4468"
+         d="m 521.25663,196.36111 -45.39766,-43.63289 -95.31662,0 -39.31645,43.9593"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 339.2104,751.90855 37.89766,43.63289 102.81662,0 39.31645,-43.9593"
+         id="path4470"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="225.71428"
+         y="-292.54883"
+         id="text4476"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan4478"
+           x="225.71428"
+           y="-292.54883">0</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="420.83691"
+         y="-93.420273"
+         id="text4480"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan4482"
+           x="420.83691"
+           y="-93.420273">2</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="754.74121"
+         y="-425.07413"
+         id="text4484"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan4486"
+           x="754.74121"
+           y="-425.07413">1</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="39.99992"
+         y="-298.26312"
+         id="text4488"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan4490"
+           x="39.99992"
+           y="-298.26312">3</tspan></text>
+      <text
+         sodipodi:linespacing="125%"
+         id="text4492"
+         y="-294.69171"
+         x="576.42853"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           y="-294.69171"
+           x="576.42853"
+           id="tspan4494"
+           sodipodi:role="line">4</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         x="573.57141"
+         y="-633.26312"
+         id="text4496"
+         sodipodi:linespacing="125%"><tspan
+           sodipodi:role="line"
+           id="tspan4498"
+           x="573.57141"
+           y="-633.26312">5</tspan></text>
+      <g
+         id="g4500"
+         transform="translate(-494.31889,-726.7283)">
+        <rect
+           y="184.3681"
+           x="461.92383"
+           height="183.59543"
+           width="185.73737"
+           id="rect4502"
+           style="opacity:1;fill:#8ae234;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4504"
+           d="m 501.56331,276.34788 0,-53.3361 53.3361,0 53.3361,0 0,53.3361 0,53.3361 -53.3361,0 -53.3361,0 0,-53.3361 z m 85.3377,26.66805 0,-5.33361 -10.6672,0 -10.6672,0 0,-5.33361 0,-5.33361 5.3336,0 5.3336,0 0,-5.33361 0,-5.33361 5.3336,0 5.3336,0 0,-10.66722 0,-10.66722 -5.3336,0 -5.3336,0 0,-5.33361 0,-5.33361 -26.6681,0 -26.668,0 0,26.66805 0,26.66805 10.6672,0 10.6672,0 0,5.33361 0,5.33361 21.3345,0 21.3344,0 0,-5.33361 z m -42.6689,-10.66722 0,-5.33361 5.3336,0 5.3337,0 0,5.33361 0,5.33361 -5.3337,0 -5.3336,0 0,-5.33361 z m -10.6672,-21.33444 0,-5.33361 5.3337,0 5.3335,0 0,5.33361 0,5.33361 -5.3335,0 -5.3337,0 0,-5.33361 z m 32.0017,0 0,-5.33361 -5.3336,0 -5.3336,0 0,-5.33361 0,-5.33361 5.3336,0 5.3336,0 0,5.33361 0,5.33361 5.3336,0 5.3336,0 0,5.33361 0,5.33361 -5.3336,0 -5.3336,0 0,-5.33361 z"
+           style="fill:#000000;fill-opacity:0.43137255" />
+        <rect
+           y="225.50793"
+           x="504.41992"
+           height="101.29921"
+           width="101.29921"
+           id="rect4506"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         id="g4508"
+         transform="translate(-308.68306,-726.7283)">
+        <rect
+           style="opacity:1;fill:#8ae234;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4510"
+           width="185.73737"
+           height="183.59543"
+           x="461.92383"
+           y="184.3681" />
+        <path
+           style="fill:#000000;fill-opacity:0.43137255"
+           d="m 501.39103,276.24125 0,-53.3361 53.3361,0 53.3361,0 0,53.3361 0,53.3361 -53.3361,0 -53.3361,0 0,-53.3361 z m 85.3377,26.66805 0,-5.33361 -5.3336,0 -5.3336,0 0,-5.33361 0,-5.33361 5.3336,0 5.3336,0 0,-5.33361 0,-5.33361 -5.3336,0 -5.3336,0 0,-5.33361 0,-5.33361 5.3336,0 5.3336,0 0,-5.33361 0,-5.33361 -5.3336,0 -5.3336,0 0,-5.33361 0,-5.33361 -26.668,0 -26.6681,0 0,21.33444 0,21.33444 10.6672,0 10.6673,0 0,-5.33361 0,-5.33361 5.3336,0 5.3336,0 0,10.66722 0,10.66722 -10.6672,0 -10.6673,0 0,5.33361 0,5.33361 26.6681,0 26.668,0 0,-5.33361 z m -53.3361,-32.00166 0,-5.33361 5.3336,0 5.3337,0 0,5.33361 0,5.33361 -5.3337,0 -5.3336,0 0,-5.33361 z m 21.3345,-10.66722 0,-5.33361 5.3336,0 5.3336,0 0,5.33361 0,5.33361 -5.3336,0 -5.3336,0 0,-5.33361 z"
+           id="path4512"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4514"
+           width="101.29921"
+           height="101.29921"
+           x="504.25562"
+           y="225.36295" />
+      </g>
+      <g
+         transform="translate(-123.80484,-726.7283)"
+         id="g4516">
+        <rect
+           y="184.3681"
+           x="461.92383"
+           height="183.59543"
+           width="185.73737"
+           id="rect4518"
+           style="opacity:1;fill:#8ae234;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4520"
+           d="m 501.41427,276.31528 0,-53.3929 53.3929,0 53.39289,0 0,53.3929 0,53.3929 -53.39289,0 -53.3929,0 0,-53.3929 z m 85.42864,26.69644 0,-5.33928 -5.33929,0 -5.33929,0 0,-5.33929 0,-5.33929 -5.3393,0 -5.33929,0 0,-5.33929 0,-5.33929 -5.33928,0 -5.33929,0 0,5.33929 0,5.33929 5.33929,0 5.33928,0 0,5.33929 0,5.33929 -10.67857,0 -10.67858,0 0,-5.33929 0,-5.33929 -5.33929,0 -5.3393,0 0,-10.67858 0,-10.67859 10.67859,0 10.67858,0 0,-5.33928 0,-5.3393 5.33929,0 5.33928,0 0,5.3393 0,5.33928 5.33929,0 5.3393,0 0,5.3393 0,5.33929 5.33929,0 5.33929,0 0,-10.67859 0,-10.67858 -5.33929,0 -5.33929,0 0,-5.33928 0,-5.33929 -26.69644,0 -26.69646,0 0,26.69645 0,26.69645 5.33928,0 5.33929,0 0,5.33928 0,5.3393 26.69646,0 26.69645,0 0,-5.3393 z"
+           style="fill:#000000;fill-opacity:0.43137255" />
+        <rect
+           y="225.40077"
+           x="504.44415"
+           height="101.29921"
+           width="101.29921"
+           id="rect4522"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         id="g4524"
+         transform="translate(61.093691,-726.7283)">
+        <rect
+           style="opacity:1;fill:#8ae234;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4526"
+           width="185.73737"
+           height="183.59543"
+           x="461.92383"
+           y="184.3681" />
+        <path
+           style="fill:#000000;fill-opacity:0.43137255"
+           d="m 501.2845,277.00506 0,-53.3361 53.3361,0 53.3361,0 0,53.3361 0,53.3361 -53.3361,0 -53.3361,0 0,-53.3361 z m 85.3378,21.33444 0,-10.66722 -5.3337,0 -5.3336,0 0,-10.66722 0,-10.66722 5.3336,0 5.3337,0 0,-5.33361 0,-5.33361 -5.3337,0 -5.3336,0 0,-5.33361 0,-5.33361 -26.668,0 -26.6681,0 0,16.00083 0,16.00083 5.3336,0 5.3337,0 0,-5.33361 0,-5.33361 5.3336,0 5.3336,0 0,21.33444 0,21.33444 21.3344,0 21.3345,0 0,-10.66722 z m -32.0017,-10.66722 0,-10.66722 5.3336,0 5.3336,0 0,5.33361 0,5.33361 5.3336,0 5.3336,0 0,5.33361 0,5.33361 -10.6672,0 -10.6672,0 0,-10.66722 z m 0,-26.66805 0,-5.33361 5.3336,0 5.3336,0 0,5.33361 0,5.33361 -5.3336,0 -5.3336,0 0,-5.33361 z"
+           id="path4528"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4530"
+           width="101.29921"
+           height="101.29921"
+           x="504.11313"
+           y="226.19606" />
+      </g>
+      <g
+         transform="translate(-123.80484,-910.34383)"
+         id="g4532">
+        <rect
+           y="184.3681"
+           x="461.92383"
+           height="183.59543"
+           width="185.73737"
+           id="rect4534"
+           style="opacity:1;fill:#8ae234;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           style="fill:#000000;fill-opacity:0.43137255"
+           d="m 501.84294,276.32724 0,-53.21429 53.2142,0 53.2143,0 0,53.21429 0,53.2143 -53.2143,0 -53.2142,0 0,-53.2143 z m 85.1429,5.32144 0,-26.60715 -5.3215,0 -5.3214,0 0,-5.32142 0,-5.32144 -26.6072,0 -26.6071,0 0,15.96429 0,15.96428 5.3215,0 5.3213,0 0,5.32144 0,5.32143 -5.3213,0 -5.3215,0 0,5.32142 0,5.32144 10.6428,0 10.6429,0 0,5.32143 0,5.32142 21.2858,0 21.2857,0 0,-26.60714 z m -21.2857,10.64285 0,-5.32142 -5.3215,0 -5.3215,0 0,-5.32143 0,-5.32144 -10.6428,0 -10.6429,0 0,-5.32143 0,-5.32141 10.6429,0 10.6428,0 0,-5.32144 0,-5.32143 5.3215,0 5.3215,0 0,5.32143 0,5.32144 5.3213,0 5.3215,0 0,15.96428 0,15.96429 -5.3215,0 -5.3213,0 0,-5.32144 z"
+           id="path4536"
+           inkscape:connector-curvature="0" />
+        <rect
+           y="225.59721"
+           x="504.5065"
+           height="101.29921"
+           width="101.29921"
+           id="rect4538"
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         id="g4540"
+         transform="translate(-123.80484,-543.87039)">
+        <rect
+           style="opacity:1;fill:#8ae234;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4542"
+           width="185.73737"
+           height="183.59543"
+           x="461.92383"
+           y="184.3681" />
+        <path
+           style="fill:#000000;fill-opacity:0.43137255"
+           d="m 501.74273,276.79728 0,-53.3361 53.3361,0 53.3361,0 0,53.3361 0,53.33611 -53.3361,0 -53.3361,0 0,-53.33611 z m 85.3378,5.33361 0,-26.66804 -5.3336,0 -5.3336,0 0,-5.33361 0,-5.33361 -26.6681,0 -26.668,0 0,16.00083 0,16.00082 5.3336,0 5.3336,0 0,-5.3336 0,-5.33361 5.3336,0 5.3336,0 0,5.33361 0,5.3336 10.6672,0 10.6672,0 0,10.66722 0,10.66722 -5.3336,0 -5.3336,0 0,-5.33361 0,-5.33361 -16.0008,0 -16.0008,0 0,5.33361 0,5.33361 5.3336,0 5.3336,0 0,5.33362 0,5.33361 26.668,0 26.6681,0 0,-26.66806 z m -21.3345,-10.66721 0,-5.33361 -5.3336,0 -5.3336,0 0,-5.33361 0,-5.33361 5.3336,0 5.3336,0 0,5.33361 0,5.33361 5.3337,0 5.3336,0 0,5.33361 0,5.3336 -5.3336,0 -5.3337,0 0,-5.3336 z"
+           id="path4544"
+           inkscape:connector-curvature="0" />
+        <rect
+           style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect4546"
+           width="101.29921"
+           height="101.29921"
+           x="504.57129"
+           y="225.86803" />
+      </g>
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4548"
+         d="m 336.98533,-723.94836 -43.63289,37.89766 0,102.81662 43.9593,39.31645"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 336.98533,-357.51979 -43.63289,37.89766 0,102.81662 43.9593,39.31645"
+         id="path4550"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4552"
+         d="m 526.36945,-177.49386 43.63289,-37.89766 0,-102.81662 -43.9593,-39.31645"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 525.3593,-545.06257 43.63289,-37.89766 0,-102.81662 -43.9593,-39.31645"
+         id="path4554"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4556"
+         d="m 708.51231,-359.63671 43.63289,-37.89766 0,-102.81662 -43.9593,-39.31645"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 521.25663,-728.93862 -45.39766,-43.63289 -95.31662,0 -39.31645,43.9593"
+         id="path4558"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4560"
+         d="m 339.2104,-173.39118 37.89766,43.63289 102.81662,0 39.31645,-43.9593"
+         style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.9992126, 2.9976378;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="fill:#000000;fill-opacity:0.43137255"
+         d="m 193.46819,474.41378 0,-52.97432 52.97439,0 52.97439,0 0,52.97432 0,52.97442 -52.97439,0 -52.97439,0 0,-52.97442 z m 84.75903,21.18982 0,-10.59487 -21.18975,0 -21.18978,0 0,-5.29749 0,-5.29746 -5.29743,0 -5.29743,0 0,-5.2974 0,-5.29739 10.59486,0 10.59489,0 0,-5.29747 0,-5.29746 5.29747,0 5.29742,0 0,10.59493 0,10.59479 5.29743,0 5.29743,0 0,-5.2974 0,-5.29739 5.29744,0 5.29745,0 0,-5.29747 0,-5.29746 -5.29745,0 -5.29744,0 0,-5.29743 0,-5.29747 -26.48717,0 -26.48719,0 0,15.89236 0,15.89226 5.29742,0 5.29744,0 0,5.29746 0,5.29749 5.29743,0 5.29743,0 0,5.2974 0,5.29747 -5.29743,0 -5.29743,0 0,5.29739 0,5.29747 26.48722,0 26.48717,0 0,-10.59486 z"
+         id="path4638"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:0.43137255"
+         d="m 563.02434,475.05795 0,-52.97439 52.97438,0 52.9744,0 0,52.97439 0,52.97436 -52.9744,0 -52.97438,0 0,-52.97436 z m 84.75901,26.48713 0,-5.29738 -21.18974,0 -21.18979,0 0,5.29738 0,5.29748 21.18979,0 21.18974,0 0,-5.29748 z m -52.97438,-26.48713 0,-10.59485 10.59485,0 10.5949,0 0,-5.29747 0,-5.2974 5.29743,0 5.29746,0 0,10.59487 0,10.59485 -10.59489,0 -10.5949,0 0,5.29743 0,5.29746 10.5949,0 10.59489,0 0,-5.29746 0,-5.29743 5.29743,0 5.29744,0 0,5.29743 0,5.29746 5.29742,0 5.29745,0 0,-5.29746 0,-5.29743 -5.29745,0 -5.29742,0 0,-5.29747 0,-5.29738 5.29742,0 5.29745,0 0,-5.29747 0,-5.2974 -5.29745,0 -5.29742,0 0,-5.29749 0,-5.2974 -26.48719,0 -26.48721,0 0,21.18976 0,21.18974 5.29747,0 5.29742,0 0,-10.59489 z"
+         id="path4636"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:0.43137255"
+         d="m 378.55944,657.74819 0,-52.97435 52.9743,0 52.97436,0 0,52.97435 0,52.97432 -52.97436,0 -52.9743,0 0,-52.97432 z m 63.5693,26.48712 0,-5.29741 5.2974,0 5.2974,0 0,-5.29745 0,-5.2974 -10.5948,0 -10.595,0 0,-5.29739 0,-5.29747 -5.2974,0 -5.2974,0 0,-5.29743 0,-5.29746 5.2974,0 5.2974,0 0,-5.29746 0,-5.29739 5.2975,0 5.2975,0 0,10.59485 0,10.59489 10.5948,0 10.5949,0 0,-10.59489 0,-10.59485 -5.2974,0 -5.2975,0 0,-5.29746 0,-5.29743 -26.4872,0 -26.4872,0 0,10.59489 0,10.59485 5.2974,0 5.2975,0 0,5.29746 0,5.29743 -5.2975,0 -5.2974,0 0,5.29747 0,5.29739 5.2974,0 5.2975,0 0,10.59485 0,10.59491 15.8923,0 15.8924,0 0,-5.2975 z m -21.1898,-10.59486 0,-5.2974 5.2974,0 5.2974,0 0,5.2974 0,5.29745 -5.2974,0 -5.2974,0 0,-5.29745 z"
+         id="path4634"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:0.43137255"
+         d="m 8.1340049,474.24375 0,-52.97441 52.9744201,0 52.974385,0 0,52.97441 0,52.97434 -52.974385,0 -52.9744201,0 0,-52.97434 z m 63.5692801,26.48712 0,-5.29739 -5.29742,0 -5.29744,0 0,-5.29746 0,-5.2974 5.29744,0 5.29742,0 0,-5.29746 0,-5.29741 5.29745,0 5.29744,0 0,10.59487 0,10.59486 5.29743,0 5.29747,0 0,-21.18973 0,-21.1898 -5.29747,0 -5.29743,0 0,-5.2974 0,-5.29747 -26.4872,0 -26.4872,0 0,10.59487 0,10.59492 5.29743,0 5.29743,0 0,5.29739 0,5.29749 5.29743,0 5.29747,0 0,-5.29749 0,-5.29739 5.29744,0 5.29745,0 0,-5.29745 0,-5.29747 5.29744,0 5.29742,0 0,10.59492 0,10.59488 -5.29742,0 -5.29744,0 0,5.29741 0,5.29746 -10.59489,0 -10.5949,0 0,5.2974 0,5.29746 5.29743,0 5.29747,0 0,5.29739 0,5.29751 10.59489,0 10.59486,0 0,-5.29751 z"
+         id="path4632"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:0.43137255"
+         d="m 378.42054,291.15786 0,-52.97429 52.9744,0 52.97438,0 0,52.97429 0,52.97437 -52.97438,0 -52.9744,0 0,-52.97437 z m 63.56925,21.18976 0,-10.59485 -5.29743,0 -5.29742,0 0,5.29746 0,5.29739 -5.29743,0 -5.29746,0 0,5.29746 0,5.29747 10.59489,0 10.59485,0 0,-10.59493 z m -31.78464,-5.29739 0,-5.29746 5.29747,0 5.29743,0 0,-10.59491 0,-10.59485 5.29746,0 5.29743,0 0,-5.29739 0,-5.29746 5.29742,0 5.29743,0 0,5.29746 0,5.29739 10.59489,0 10.5949,0 0,-5.29739 0,-5.29746 -5.29747,0 -5.29743,0 0,-5.29741 0,-5.29749 -26.48717,0 -26.48722,0 0,10.5949 0,10.59485 5.29742,0 5.29744,0 0,5.29746 0,5.29739 -5.29744,0 -5.29742,0 0,10.59491 0,10.59485 5.29742,0 5.29744,0 0,-5.29739 z m 52.97443,-10.59487 0,-5.2975 -5.29747,0 -5.29743,0 0,5.2975 0,5.29741 5.29743,0 5.29747,0 0,-5.29741 z"
+         id="path4630"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:0.43137255"
+         d="m 378.11808,474.73541 0,-53.1496 53.14961,0 53.1496,0 0,53.1496 0,53.1496 -53.1496,0 -53.14961,0 0,-53.1496 z m 63.77953,26.5748 0,-5.315 10.62991,0 10.62993,0 0,-5.3149 0,-5.315 -10.62993,0 -10.62991,0 0,-5.3149 0,-5.315 -10.62992,0 -10.62992,0 0,-5.315 0,-5.3149 5.31496,0 5.31496,0 0,-5.315 0,-5.3149 5.31496,0 5.31496,0 0,5.3149 0,5.315 10.62991,0 10.62993,0 0,-5.315 0,-5.3149 -5.31496,0 -5.31497,0 0,-5.315 0,-5.315 -26.57479,0 -26.57481,0 0,10.63 0,10.6299 5.31496,0 5.31496,0 0,5.3149 0,5.315 5.31496,0 5.31497,0 0,10.6299 0,10.6299 -5.31497,0 -5.31496,0 0,-5.3149 0,-5.315 -5.31496,0 -5.31496,0 0,5.315 0,5.3149 5.31496,0 5.31496,0 0,5.315 0,5.315 15.94489,0 15.94488,0 0,-5.315 z m -10.62992,-10.6299 0,-5.315 5.31496,0 5.31496,0 0,5.315 0,5.3149 -5.31496,0 -5.31496,0 0,-5.3149 z"
+         id="path4651"
+         inkscape:connector-curvature="0" />
+    </g>
+    <text
+       sodipodi:linespacing="125%"
+       id="text4472"
+       y="86.924637"
+       x="-858.65247"
+       style="font-style:normal;font-weight:normal;font-size:16.00360489px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       xml:space="preserve"><tspan
+         y="86.924637"
+         x="-858.65247"
+         id="tspan4474"
+         sodipodi:role="line">size: 30mm</tspan></text>
+  </g>
+</svg>

--- a/samples/tag_configuration_cube.yml
+++ b/samples/tag_configuration_cube.yml
@@ -1,0 +1,34 @@
+%YAML:1.0
+
+blue_cube:
+    - tag: 6
+      size: 30
+      rotation: [180., 0., 0]
+      translation: [-15.0, 15.0, 25.9]
+      keep: 0
+    - tag: 7
+      size: 30
+      rotation: [0., 0., 180]
+      translation: [15.0, 15.0, -25.9]
+      keep: 0
+    - tag: 8
+      size: 30
+      translation: [15.0, -25.9, 15.0]
+      rotation: [-90., 0., 90]
+      keep: 0
+    - tag: 9
+      size: 30
+      translation: [-25.9, 15.0, -15.]
+      rotation: [0., 90., 180]
+      keep: 0
+    - tag: 10
+      size: 30
+      translation: [25.9, 15.0, 15.]
+      rotation: [180., -90., 0]
+      keep: 0
+    - tag: 11
+      size: 30
+      translation: [-15.0, 25.9, 15.0]
+      rotation: [90., 0., -90]
+      keep: 0
+


### PR DESCRIPTION
Note that the time is printed on `std::cerr`, which ensure that `detect_from_file` output can still be piped into another process as previously.

While here, read the source image directly in grayscale