### PR TITLE
Isolated detection into its own object

### DIFF
--- a/src/Detect.cpp
+++ b/src/Detect.cpp
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ *   Copyright 2013-2014 EPFL                                                   *
+ *   Copyright 2013-2014 Quentin Bonnard                                        *
+ *   Copyright 2013-2014 Ayberk Özgür                                           *
+ *                                                                              *
+ *   This file is part of chilitags.                                            *
+ *                                                                              *
+ *   Chilitags is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the Lesser GNU General Public License as             *
+ *   published by the Free Software Foundation, either version 3 of the         *
+ *   License, or (at your option) any later version.                            *
+ *                                                                              *
+ *   Chilitags is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ *   GNU Lesser General Public License for more details.                        *
+ *                                                                              *
+ *   You should have received a copy of the GNU Lesser General Public License   *
+ *   along with Chilitags.  If not, see <http://www.gnu.org/licenses/>.         *
+ *******************************************************************************/
+
+#include "Detect.hpp"
+
+chilitags::Detect::Detect() :
+    mRefineCorners(true),
+    mFindQuads(),
+    mRefine(),
+    mReadBits(),
+    mDecode()
+{
+}
+
+void chilitags::Detect::setMinInputWidth(int minWidth) {
+    mFindQuads.setMinInputWidth(minWidth);
+}
+
+void chilitags::Detect::setCornerRefinement(bool refineCorners) {
+    mRefineCorners = refineCorners;
+}
+
+void chilitags::Detect::operator()(cv::Mat const& greyscaleImage, std::map<int, Quad>& tags) {
+    if(mRefineCorners){
+        for(const auto& quad : mFindQuads(greyscaleImage)){
+            auto refinedQuad = mRefine(greyscaleImage, quad, 1.5/10.);
+            auto tag = mDecode(mReadBits(greyscaleImage, refinedQuad), refinedQuad);
+            if(tag.first != Decode::INVALID_TAG)
+                tags[tag.first] = tag.second;
+            else{
+                tag = mDecode(mReadBits(greyscaleImage, quad), quad);
+                if(tag.first != Decode::INVALID_TAG)
+                    tags[tag.first] = tag.second;
+            }
+        }
+    }
+    else{
+        for(const auto& quad : mFindQuads(greyscaleImage)){
+            auto tag = mDecode(mReadBits(greyscaleImage, quad), quad);
+            if(tag.first != Decode::INVALID_TAG)
+                tags[tag.first] = tag.second;
+        }
+    }
+}

--- a/src/Detect.hpp
+++ b/src/Detect.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ *   Copyright 2013-2014 EPFL                                                   *
+ *   Copyright 2013-2014 Quentin Bonnard                                        *
+ *   Copyright 2013-2014 Ayberk Özgür                                           *
+ *                                                                              *
+ *   This file is part of chilitags.                                            *
+ *                                                                              *
+ *   Chilitags is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the Lesser GNU General Public License as             *
+ *   published by the Free Software Foundation, either version 3 of the         *
+ *   License, or (at your option) any later version.                            *
+ *                                                                              *
+ *   Chilitags is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ *   GNU Lesser General Public License for more details.                        *
+ *                                                                              *
+ *   You should have received a copy of the GNU Lesser General Public License   *
+ *   along with Chilitags.  If not, see <http://www.gnu.org/licenses/>.         *
+ *******************************************************************************/
+
+#ifndef DETECT_HPP
+#define DETECT_HPP
+
+#include <map>
+#include <opencv2/core/core.hpp>
+#include "FindQuads.hpp"
+#include "Decode.hpp"
+#include "Refine.hpp"
+#include "ReadBits.hpp"
+
+namespace chilitags {
+
+class Detect {
+
+public:
+
+    Detect();
+
+    void setMinInputWidth(int minWidth);
+
+    void setCornerRefinement(bool refineCorners);
+
+    void operator()(cv::Mat const& inputImage, std::map<int, Quad>& tags);
+
+protected:
+
+    bool mRefineCorners;
+    FindQuads mFindQuads;
+    Refine mRefine;
+    ReadBits mReadBits;
+    Decode mDecode;
+};
+
+} /* namespace chilitags */
+
+#endif /* DETECT_HPP */


### PR DESCRIPTION
Isolated tag detection into its own object along with all related objects: corner refinement, quad finding, bit reading and decoding (though this also exists in `Chilitags`).

This makes `Chilitags::find()` much lighter and detection/tracking distinction much more visible. This will in turn make life much easier when separating them into different threads, and also when making detection concurrent in the future.

This is a purely refactoring PR, does not change the API or performance. 
