### PR TITLE
Separated pnp, rodrigues and related stuff into its own object

### DIFF
--- a/src/Chilitags3D.cpp
+++ b/src/Chilitags3D.cpp
@@ -21,7 +21,7 @@
 #include <chilitags.hpp>
 
 #include "Filter.hpp"
-#include "CalcTf3D.hpp"
+#include "EstimatePose3D.hpp"
 
 #include <iostream>
 #include <opencv2/highgui/highgui.hpp> //for FileStorage
@@ -40,7 +40,7 @@ Impl(cv::Size cameraResolution) :
     mOmitOtherTags(false),
     mDefaultTagCorners(),
     mId2Configuration(),
-    mCalcTf3D(cameraResolution),
+    mEstimatePose3D(cameraResolution),
     mFilter(5, 0.5f)
 {
     setDefaultTagSize(20.f);
@@ -84,7 +84,7 @@ TagPoseMap estimate(const TagCornerMap &tags) {
             if (configurationIt->first == tagId) {
                 const auto &configuration = configurationIt->second;
                 if (configuration.second.mKeep) {
-                    mCalcTf3D(cv::format("tag_%d", tagId),
+                    mEstimatePose3D(cv::format("tag_%d", tagId),
                                           configuration.second.mLocalcorners,
                                           corners,
                                           objects);
@@ -99,14 +99,14 @@ TagPoseMap estimate(const TagCornerMap &tags) {
                     corners.begin(),
                     corners.end());
             } else if (!mOmitOtherTags) {
-                mCalcTf3D(cv::format("tag_%d", tagId),
+                mEstimatePose3D(cv::format("tag_%d", tagId),
                                       mDefaultTagCorners,
                                       corners,
                                       objects);
             }
 
         } else if (!mOmitOtherTags) {
-            mCalcTf3D(cv::format("tag_%d", tagId),
+            mEstimatePose3D(cv::format("tag_%d", tagId),
                                   mDefaultTagCorners,
                                   corners,
                                   objects);
@@ -114,7 +114,7 @@ TagPoseMap estimate(const TagCornerMap &tags) {
     }
 
     for (auto& objectToPoints : objectToPointMapping) {
-        mCalcTf3D(objectToPoints.first,
+        mEstimatePose3D(objectToPoints.first,
                               objectToPoints.second.first,
                               cv::Mat_<cv::Point2f>(objectToPoints.second.second),
                               objects);
@@ -187,7 +187,7 @@ bool read3DConfiguration(const std::string &filenameOrString, bool omitOtherTags
  */
 void setCalibration(cv::InputArray newCameraMatrix,
                     cv::InputArray newDistCoeffs){
-    mCalcTf3D.setCameraCalibration(newCameraMatrix.getMat(), newDistCoeffs.getMat());
+    mEstimatePose3D.setCameraCalibration(newCameraMatrix.getMat(), newDistCoeffs.getMat());
 }
 
 cv::Size readCalibration(const std::string &filename) {
@@ -203,13 +203,13 @@ cv::Size readCalibration(const std::string &filename) {
         distCoeffs = cv::Mat_<float>(distCoeffs);
     if( cameraMatrix.type() != CV_32F )
         cameraMatrix = cv::Mat_<float>(cameraMatrix);
-    mCalcTf3D.setCameraCalibration(cameraMatrix, distCoeffs);
+    mEstimatePose3D.setCameraCalibration(cameraMatrix, distCoeffs);
 
     return size;
 }
 
-const cv::Mat &getCameraMatrix()     const {return mCalcTf3D.getCameraMatrix();}
-const cv::Mat &getDistortionCoeffs() const{return mCalcTf3D.getDistortionCoeffs();}
+const cv::Mat &getCameraMatrix()     const {return mEstimatePose3D.getCameraMatrix();}
+const cv::Mat &getDistortionCoeffs() const{return mEstimatePose3D.getDistortionCoeffs();}
 
 private:
 
@@ -276,7 +276,7 @@ struct TagConfig {
 
 Chilitags mChilitags;
 
-CalcTf3D<RealT> mCalcTf3D;
+EstimatePose3D<RealT> mEstimatePose3D;
 
 bool mOmitOtherTags;
 

--- a/src/EstimatePose3D.cpp
+++ b/src/EstimatePose3D.cpp
@@ -19,20 +19,20 @@
  *******************************************************************************/
 
 /**
- * @file CalcTf3D.cpp
+ * @file EstimatePose3D.cpp
  * @brief 6D pose calculator from image coordinates and camera parameters
  * @author Quentin Bonnard
  * @author Ayberk Özgür
  */
 
-#include "CalcTf3D.hpp"
+#include "EstimatePose3D.hpp"
 
 #include <opencv2/calib3d/calib3d.hpp>
 
 namespace chilitags{
 
 template<typename RealT>
-CalcTf3D<RealT>::CalcTf3D(cv::Size cameraResolution) :
+EstimatePose3D<RealT>::EstimatePose3D(cv::Size cameraResolution) :
     mCameraMatrix(),
     mDistCoeffs()
 {
@@ -45,26 +45,26 @@ CalcTf3D<RealT>::CalcTf3D(cv::Size cameraResolution) :
 }
 
 template<typename RealT>
-void CalcTf3D<RealT>::setCameraCalibration(cv::Mat newCameraMatrix, cv::Mat newDistCoeffs)
+void EstimatePose3D<RealT>::setCameraCalibration(cv::Mat newCameraMatrix, cv::Mat newDistCoeffs)
 {
     mCameraMatrix = newCameraMatrix;
     mDistCoeffs = newDistCoeffs;
 }
 
 template<typename RealT>
-cv::Mat const& CalcTf3D<RealT>::getCameraMatrix() const
+cv::Mat const& EstimatePose3D<RealT>::getCameraMatrix() const
 {
     return mCameraMatrix;
 }
 
 template<typename RealT>
-cv::Mat const& CalcTf3D<RealT>::getDistortionCoeffs() const
+cv::Mat const& EstimatePose3D<RealT>::getDistortionCoeffs() const
 {
     return mDistCoeffs;
 }
 
 template<typename RealT>
-void CalcTf3D<RealT>::operator()(std::string const& name,
+void EstimatePose3D<RealT>::operator()(std::string const& name,
         std::vector<cv::Point3_<RealT>> const& objectPoints,
         cv::Mat_<cv::Point2f> const& imagePoints,
         typename Chilitags3D_<RealT>::TagPoseMap& objects)
@@ -91,8 +91,8 @@ void CalcTf3D<RealT>::operator()(std::string const& name,
     };
 }
 
-//All possible instantiations of CalcTf3D
-template class CalcTf3D<float>;
-template class CalcTf3D<double>;
+//All possible instantiations of EstimatePose3D
+template class EstimatePose3D<float>;
+template class EstimatePose3D<double>;
 
 } /* namespace chilitags */

--- a/src/EstimatePose3D.hpp
+++ b/src/EstimatePose3D.hpp
@@ -19,14 +19,14 @@
  *******************************************************************************/
 
 /**
- * @file CalcTf3D.cpp
+ * @file EstimatePose3D.cpp
  * @brief 6D pose calculator from image coordinates and camera parameters
  * @author Quentin Bonnard
  * @author Ayberk Özgür
  */
 
-#ifndef CALCTF3D_HPP
-#define CALCTF3D_HPP
+#ifndef ESTIMATEPOSE3D_HPP
+#define ESTIMATEPOSE3D_HPP
 
 #include <vector>
 #include <map>
@@ -37,7 +37,7 @@
 namespace chilitags {
 
 template<typename RealT>
-class CalcTf3D
+class EstimatePose3D
 {
 public:
 
@@ -46,7 +46,7 @@ public:
      *
      * @param cameraResolution Height and width of the camera image
      */
-    CalcTf3D(cv::Size cameraResolution = cv::Size(640,480));
+    EstimatePose3D(cv::Size cameraResolution = cv::Size(640,480));
 
     /**
      * @brief Updates the camera calibration parameters
@@ -100,4 +100,4 @@ protected:
 
 } /* namespace chilitags */
 
-#endif /* CALCTF3D_HPP */
+#endif /* ESTIMATEPOSE3D_HPP */


### PR DESCRIPTION
This shortens and simplifies Chiltiags3D a little bit and also will allow a cleaner next step which is noise filtering on the 3D pose and then the integration of the IMU if present. 

This is a purely refactoring PR, API/performance is not changed.
