### PR TITLE
add reprojection-based precision benchmark

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,6 +54,7 @@ declare_test(TESTNAME integration)
 declare_test(TESTNAME pose-estimation NEEDS_DATA)
 declare_test(TESTNAME detection-performance NEEDS_DATA)
 declare_test(TESTNAME float-precision NEEDS_DATA)
+declare_test(TESTNAME precision NEEDS_DATA)
 
 add_executable(find-crash find-crash.cpp)
 target_link_libraries(find-crash chilitags)

--- a/test/DetectionTestCase.hpp
+++ b/test/DetectionTestCase.hpp
@@ -21,9 +21,9 @@
 #ifndef TestMetadata_HPP
 #define TestMetadata_HPP
 
-namespace TestMetadata {
+namespace chilitags {
 
-struct TestCase {
+struct DetectionTestCase {
     std::string filename;
     std::vector<int> expectedTagIds;
     std::vector<int> knownMissedTagIds;
@@ -36,12 +36,14 @@ struct TestCase {
     static bool contains(const std::vector<int> &v, int x) {
         return std::find(v.begin(), v.end(), x) != v.end();
     }
+
+    const static std::vector< DetectionTestCase > all;
 };
 
 // The string is the filename of an image,
 // the first list correspond to the ids of tags shown on the image,
 // and the second list to the ids of the tags that are undetected.
-std::vector< TestCase > all = {
+const std::vector< DetectionTestCase > DetectionTestCase::all = {
     {"stills/4360x2448/smartphone01.jpg",
         {0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34},
      {}},
@@ -139,6 +141,7 @@ std::vector< TestCase > all = {
         {50, 51, 55, 62},
         {62,}},
 };
+
 }
 
 #endif

--- a/test/LocalisationTestCase.hpp
+++ b/test/LocalisationTestCase.hpp
@@ -1,0 +1,54 @@
+/*******************************************************************************
+*   Copyright 2013-2014 EPFL                                                   *
+*   Copyright 2013-2014 Quentin Bonnard                                        *
+*                                                                              *
+*   This file is part of chilitags.                                            *
+*                                                                              *
+*   Chilitags is free software: you can redistribute it and/or modify          *
+*   it under the terms of the Lesser GNU General Public License as             *
+*   published by the Free Software Foundation, either version 3 of the         *
+*   License, or (at your option) any later version.                            *
+*                                                                              *
+*   Chilitags is distributed in the hope that it will be useful,               *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+*   GNU Lesser General Public License for more details.                        *
+*                                                                              *
+*   You should have received a copy of the GNU Lesser General Public License   *
+*   along with Chilitags.  If not, see <http://www.gnu.org/licenses/>.         *
+*******************************************************************************/
+
+#ifndef TestMetadata_HPP
+#define TestMetadata_HPP
+
+namespace chilitags {
+
+struct LocalisationTestCase {
+    std::string file;
+    int tagCols;
+    float tagSize;
+    float gutterSize;
+
+    cv::Point3f cornerPositionInObject(int tagId, int cornerId) const {
+        const float cornerX[4] = { 0.f, tagSize, tagSize, 0.f };
+        const float cornerY[4] = { 0.f, 0.f, tagSize, tagSize };
+
+        return {
+            gutterSize+(tagSize+gutterSize)*static_cast<float>(tagId%tagCols)
+                +cornerX[cornerId],
+            gutterSize+(tagSize+gutterSize)*static_cast<float>(tagId/tagCols)
+                +cornerY[cornerId],
+            0.0f};
+    }
+
+    static const std::vector<LocalisationTestCase> all;
+
+};
+
+    const std::vector<LocalisationTestCase> LocalisationTestCase::all = {
+        {"tagGrids/artificial.png", 10, 20.0f, 10.0f}
+    };
+
+}
+
+#endif

--- a/test/TestUtils.hpp
+++ b/test/TestUtils.hpp
@@ -1,0 +1,51 @@
+/*******************************************************************************
+*   Copyright 2013-2014 EPFL                                                   *
+*   Copyright 2013-2014 Quentin Bonnard                                        *
+*                                                                              *
+*   This file is part of chilitags.                                            *
+*                                                                              *
+*   Chilitags is free software: you can redistribute it and/or modify          *
+*   it under the terms of the Lesser GNU General Public License as             *
+*   published by the Free Software Foundation, either version 3 of the         *
+*   License, or (at your option) any later version.                            *
+*                                                                              *
+*   Chilitags is distributed in the hope that it will be useful,               *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+*   GNU Lesser General Public License for more details.                        *
+*                                                                              *
+*   You should have received a copy of the GNU Lesser General Public License   *
+*   along with Chilitags.  If not, see <http://www.gnu.org/licenses/>.         *
+*******************************************************************************/
+
+#ifndef TestUtils_HPP
+#define TestUtils_HPP
+
+#include <opencv2/core/core.hpp>
+
+namespace TestUtils {
+
+float mean(const std::vector<float>& vals)
+{
+    float sum = 0.0f;
+    for(auto v : vals) sum += v;
+    return sum/vals.size();
+}
+
+float variance(const std::vector<float>& vals)
+{
+    float current_mean = mean(vals);
+    float temp = 0;
+    for(auto v : vals)
+        temp += (current_mean-v)*(current_mean-v);
+    return temp/vals.size();
+}
+
+float sigma(const std::vector<float>& vals)
+{
+    return std::sqrt(variance(vals));
+}
+
+}
+
+#endif

--- a/test/detection-performance.cpp
+++ b/test/detection-performance.cpp
@@ -26,7 +26,8 @@
 
 #include <opencv2/highgui/highgui.hpp>
 
-#include "test-metadata.hpp"
+#include "DetectionTestCase.hpp"
+#include "TestUtils.hpp"
 
 #include <chilitags.hpp>
 
@@ -50,27 +51,6 @@ using namespace std;
 
 namespace {
 
-float mean(const vector<float>& vals)
-{
-    float sum = 0.0f;
-    for(auto v : vals) sum += v;
-    return sum/vals.size();
-}
-
-float variance(const vector<float>& vals)
-{
-    float current_mean = mean(vals);
-    float temp = 0;
-    for(auto v : vals)
-        temp += (current_mean-v)*(current_mean-v);
-    return temp/vals.size();
-}
-
-float sigma(const vector<float>& vals)
-{
-    return sqrt(variance(vals));
-}
-
 std::vector<int> my_set_difference(
     const std::vector<int> & v1,
     const std::vector<int> & v2) {
@@ -83,6 +63,7 @@ std::vector<int> my_set_difference(
     difference.resize(differenceEnd - difference.begin());
     return difference;
 }
+
 }
 
 TEST(Integration, Snapshots) {
@@ -107,7 +88,7 @@ TEST(Integration, Snapshots) {
     map<int, vector<float> > referenceDuration;
     map<int, int> referenceFalseNegatives;
 
-    for (auto testCase : TestMetadata::all) {
+    for (auto testCase : chilitags::DetectionTestCase::all) {
         std::string path = std::string(cvtest::TS::ptr()->get_data_path())+testCase.filename;
         cv::Mat image = cv::imread(path);
 
@@ -183,8 +164,8 @@ TEST(Integration, Snapshots) {
         cout
         << std::setw(3) << durations.second.size()/ITERATIONS
         << std::setw(10) << resolution[durations.first]
-        << std::setw(10) << std::fixed << std::setprecision(1) << mean(durations.second)
-        << std::setw(10) << std::fixed << std::setprecision(1) << sigma(durations.second)
+        << std::setw(10) << std::fixed << std::setprecision(1) << TestUtils::mean(durations.second)
+        << std::setw(10) << std::fixed << std::setprecision(1) << TestUtils::sigma(durations.second)
         << "\n";
     }
 
@@ -210,7 +191,7 @@ TEST(Integration, Snapshots) {
     map<int, vector<float> > perfDurations;
     map<int, int > perfFalseNegatives;
     int perfTotalFalseNegatives = 0;
-    for (auto testCase : TestMetadata::all) {
+    for (auto testCase : chilitags::DetectionTestCase::all) {
         std::string path = std::string(cvtest::TS::ptr()->get_data_path())+testCase.filename;
         cv::Mat image = cv::imread(path);
 
@@ -255,7 +236,7 @@ TEST(Integration, Snapshots) {
             << std::setw(3) << durations.second.size()/ITERATIONS
             << std::setw(10) << resolution[durations.first]
             << std::setw(17) << std::fixed << std::setprecision(0) <<
-                mean(perfDurationsIt->second) << "%"
+                TestUtils::mean(perfDurationsIt->second) << "%"
             << std::setw(11) << perfFalseNegativesIt->second
             << " vs "
             << std::setw(3) << referenceFalseNegativesIt->second

--- a/test/float-precision.cpp
+++ b/test/float-precision.cpp
@@ -26,7 +26,7 @@
 
 #include <opencv2/highgui/highgui.hpp>
 
-#include "test-metadata.hpp"
+#include "DetectionTestCase.hpp"
 
 #include <chilitags.hpp>
 
@@ -50,7 +50,7 @@ TEST(FloatPrecision, Snapshots) {
     chilitagsd.getChilitags().setPerformance(chilitags::Chilitags::ROBUST);
     chilitagsd.setFilter(0, 0.0f);
 
-    for (auto testCase : TestMetadata::all) {
+    for (auto testCase : chilitags::DetectionTestCase::all) {
         std::string path = std::string(cvtest::TS::ptr()->get_data_path())+testCase.filename;
         cv::Mat image = cv::imread(path);
 

--- a/test/precision.cpp
+++ b/test/precision.cpp
@@ -1,0 +1,118 @@
+/********************************************************************************
+ *   Copyright 2013-2014 EPFL                                                   *
+ *   Copyright 2013-2014 Quentin Bonnard                                        *
+ *                                                                              *
+ *   This file is part of chilitags.                                            *
+ *                                                                              *
+ *   Chilitags is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the Lesser GNU General Public License as             *
+ *   published by the Free Software Foundation, either version 3 of the         *
+ *   License, or (at your option) any later version.                            *
+ *                                                                              *
+ *   Chilitags is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ *   GNU Lesser General Public License for more details.                        *
+ *                                                                              *
+ *   You should have received a copy of the GNU Lesser General Public License   *
+ *   along with Chilitags.  If not, see <http://www.gnu.org/licenses/>.         *
+ *******************************************************************************/
+
+#include<fstream>
+#include<string>
+
+#ifdef OPENCV3
+#include <opencv2/ts.hpp>
+#else
+#include <opencv2/ts/ts.hpp>
+#endif
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
+
+#include <chilitags.hpp>
+#include "LocalisationTestCase.hpp"
+#include "TestUtils.hpp"
+
+void run(const chilitags::LocalisationTestCase &testCase)
+{
+
+    chilitags::Chilitags chilitags;
+    chilitags.setPerformance(chilitags::Chilitags::ROBUST);
+    chilitags.setFilter(0, 0.f);
+
+    cvtest::TS::ptr()->init("");
+    std::string path = std::string(cvtest::TS::ptr()->get_data_path())+testCase.file;
+    cv::Mat inputImage = cv::imread(path);
+    if(!inputImage.data) {
+        ADD_FAILURE()
+            << "Unable to read: " << path << "\n"
+            << "Did you correctly set the OPENCV_TEST_DATA_PATH environment variable?\n"
+            << "CMake takes care of this if you set its TEST_DATA variable.\n"
+            << "You can download the test data from\n"
+            << "https://github.com/chili-epfl/chilitags-testdata";
+        return;
+    }
+
+    auto tags = chilitags.find(inputImage, chilitags::Chilitags::DETECT_ONLY);
+
+    std::vector<cv::Point2f> imagePoints;
+    std::vector<cv::Point3f> objectPoints;
+    for (auto & tag : tags) {
+        const int id = tag.first;
+        const cv::Mat_<cv::Point2f> corners(tag.second);
+
+        for (size_t i = 0; i < 4; ++i) {
+            objectPoints.push_back(testCase.cornerPositionInObject(id, i));
+            imagePoints.push_back(corners(i));
+        }
+    }
+
+    static const cv::Size CAMERA_SIZE(640, 480);
+    static const float FOCAL_LENGTH = 700.0f;
+    static const cv::Matx33f cameraMatrix = {
+        FOCAL_LENGTH , 0            , (float) CAMERA_SIZE.width /2,
+        0            , FOCAL_LENGTH , (float) CAMERA_SIZE.height/2,
+        0            , 0            , 1
+    };
+    static cv::Mat distCoeffs;
+
+    cv::Mat rotation;
+    cv::Mat translation;
+
+    cv::solvePnP(objectPoints,
+                 imagePoints,
+                 cameraMatrix, distCoeffs,
+                 rotation, translation, false,
+#ifdef OPENCV3
+                 cv::SOLVEPNP_ITERATIVE);
+#else
+                 cv::ITERATIVE);
+#endif
+
+    std::vector<cv::Point2f> projectedPoints;
+    projectPoints(cv::Mat(objectPoints), rotation, translation,
+                  cameraMatrix, distCoeffs, projectedPoints);
+
+    auto nPoints = imagePoints.size();
+    std::vector<float> errors;
+    for (std::size_t i = 0; i<nPoints; ++i) {
+        errors.push_back(cv::norm(imagePoints[i] - projectedPoints[i]));
+    }
+
+    float relativeMeanError = TestUtils::mean(errors)/testCase.tagSize;
+    float relativeSigma = TestUtils::variance(errors)/testCase.tagSize;
+
+    EXPECT_GT(0.01f, relativeMeanError);
+    EXPECT_GT(0.005f, relativeSigma);
+}
+
+
+TEST(Precision, Screenshot) {
+    for (const auto &testCase : chilitags::LocalisationTestCase::all) {
+        run(testCase);
+    }
+}
+
+CV_TEST_MAIN(".")


### PR DESCRIPTION
This is a work in progress to discuss a reprojection based benchmark to measure the precision of the location of the tags
