### PR TITLE
Inverted tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ message(STATUS "OpenCV version: ${OpenCV_VERSION}")
 option(WITH_SAMPLES                     "Build demos" OFF)
 option(WITH_TESTS                       "Build tests" OFF)
 option(WITH_JNI_BINDINGS                "Build JNI bindings compatible with ordinary Java and Android" OFF)
+option(WITH_INVERTED_TAGS               "Support for 'inverted' tags" OFF)
 option(ANDROID_INSTALL_LIBRARIES        "Install the chilitag libraries inside project at ANDROID_PROJECT_ROOT" OFF)
 
 if(DEFINED ANDROID) #OPENCV has a nice macro for this: OCV_OPTION, consider using it.
@@ -75,6 +76,10 @@ endif()
 
 if(WITH_PTHREADS)
     add_definitions(-DHAS_MULTITHREADING)
+endif()
+
+if(WITH_INVERTED_TAGS)
+    add_definitions(-DHAS_INVERTED_TAGS)
 endif()
 
 if(${OpenCV_VERSION} VERSION_GREATER 2.9.0)

--- a/samples/detection/detect-live.cpp
+++ b/samples/detection/detect-live.cpp
@@ -36,10 +36,22 @@
 #include <opencv2/highgui/highgui.hpp>
 
 #include <iostream>
+#include <csignal>
 
+
+bool sRunning = true;
+cv::VideoCapture capture;
+
+void quitFunction(int sig) {
+    std::cout << "Caught interrupt. Closing" << std::endl;
+    capture.release();
+    sRunning = false;
+}
 
 int main(int argc, char* argv[])
 {
+    signal(SIGINT, quitFunction);
+
     // Simple parsing of the parameters related to the image acquisition
     int xRes = 640;
     int yRes = 480;
@@ -53,7 +65,7 @@ int main(int argc, char* argv[])
     }
 
     // The source of input images
-    cv::VideoCapture capture(cameraIndex);
+    capture.open(cameraIndex);
     if (!capture.isOpened())
     {
         std::cerr << "Unable to initialise video capture." << std::endl;
@@ -81,7 +93,7 @@ int main(int argc, char* argv[])
 
     cv::namedWindow("DisplayChilitags");
     // Main loop, exiting when 'q is pressed'
-    for (; 'q' != (char) cv::waitKey(1); ) {
+    for (; 'q' != (char) cv::waitKey(1) and sRunning; ) {
 
         // Capture a new image.
         capture.read(inputImage);

--- a/src/Decode.cpp
+++ b/src/Decode.cpp
@@ -46,12 +46,14 @@ Decode::~Decode()
 std::pair<int, Quad> Decode::operator()(const std::vector<unsigned char> &bits, const Quad &corners)
 {
     auto result = doDecode(bits, corners);
+#ifdef HAS_INVERTED_TAGS
     if (result.first == INVALID_TAG) {
         //flip the bits, in case this tag is inverted
         std::vector<unsigned char> flippedBits(bits.size());
         std::transform(bits.begin(), bits.end(), flippedBits.begin(), [](const unsigned char& c) { return 1 - c; });
         result = doDecode(flippedBits, corners);
     }
+#endif
     return result;
 }
 

--- a/src/Decode.cpp
+++ b/src/Decode.cpp
@@ -19,6 +19,7 @@
 *******************************************************************************/
 
 #include "Decode.hpp"
+#include <iostream>
 
 namespace chilitags{
 
@@ -43,6 +44,18 @@ Decode::~Decode()
 }
 
 std::pair<int, Quad> Decode::operator()(const std::vector<unsigned char> &bits, const Quad &corners)
+{
+    auto result = doDecode(bits, corners);
+    if (result.first == INVALID_TAG) {
+        //flip the bits, in case this tag is inverted
+        std::vector<unsigned char> flippedBits(bits.size());
+        std::transform(bits.begin(), bits.end(), flippedBits.begin(), [](const unsigned char& c) { return 1 - c; });
+        result = doDecode(flippedBits, corners);
+    }
+    return result;
+}
+
+std::pair<int, Quad> Decode::doDecode(const std::vector<unsigned char> &bits, const Quad &corners)
 {
     for (int i = 0; i < DATA_SIZE; ++i)
     {

--- a/src/Decode.hpp
+++ b/src/Decode.hpp
@@ -40,6 +40,8 @@ std::pair<int, Quad> operator()(
     const std::vector<unsigned char> &bits,
     const Quad &corners);
 
+std::pair<int, Quad> doDecode(const std::vector<unsigned char> &bits, const Quad &corners);
+
 const Codec &getCodec() const {
     return mCodec;
 }

--- a/src/ReadBits.cpp
+++ b/src/ReadBits.cpp
@@ -113,6 +113,8 @@ const std::vector<unsigned char>& ReadBits::operator()(const cv::Mat &inputImage
     cv::threshold(mSamples, mBits, -1, 1, cv::THRESH_BINARY | cv::THRESH_OTSU);
 
 #ifdef DEBUG_ReadBits
+    std::cout << "Samples   " << cv::Mat(mSamples) << std::endl;
+    std::cout << "Bits      " << cv::Mat(mBits) << std::endl;
 
     for (int i = 0; i < DATA_SIZE; ++i)
     {

--- a/src/ReadBits.cpp
+++ b/src/ReadBits.cpp
@@ -113,9 +113,6 @@ const std::vector<unsigned char>& ReadBits::operator()(const cv::Mat &inputImage
     cv::threshold(mSamples, mBits, -1, 1, cv::THRESH_BINARY | cv::THRESH_OTSU);
 
 #ifdef DEBUG_ReadBits
-    std::cout << "Samples   " << cv::Mat(mSamples) << std::endl;
-    std::cout << "Bits      " << cv::Mat(mBits) << std::endl;
-
     for (int i = 0; i < DATA_SIZE; ++i)
     {
         for (int j = 0; j < DATA_SIZE; ++j)


### PR DESCRIPTION
This patch allows reading "inverted" tags (white instead of black), by flipping the detected "bits"