### PR TITLE
fix windows dll build

### DIFF
--- a/include/chilitags.hpp
+++ b/include/chilitags.hpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <memory>
 
+#include "chilitags_export.hpp"
+
 namespace chilitags {
 
 /**
@@ -54,7 +56,7 @@ typedef std::map<int, Quad> TagCornerMap;
     It also provides some utilities, like encoding and decoding id's to/from
     bit matrices, or drawing a given tag.
  */
-class Chilitags
+class CHILITAGS_EXPORT Chilitags
 {
 
 public:
@@ -336,7 +338,7 @@ std::unique_ptr<Impl> mImpl;
     (2D) detection.
  */
 template<typename RealT = float>
-class Chilitags3D_
+class CHILITAGS_EXPORT Chilitags3D_
 {
 
 public:

--- a/samples/detection/detect-live.cpp
+++ b/samples/detection/detect-live.cpp
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
 
     cv::namedWindow("DisplayChilitags");
     // Main loop, exiting when 'q is pressed'
-    for (; 'q' != (char) cv::waitKey(1) and sRunning; ) {
+    for (; 'q' != (char) cv::waitKey(1) && sRunning; ) {
 
         // Capture a new image.
         capture.read(inputImage);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,25 @@ add_library(
         ${chilitags_source}
 )
 
+include(GenerateExportHeader)
+generate_export_header(chilitags
+    BASE_NAME CHILITAGS
+    EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/chilitags_export.hpp
+)
+
+target_include_directories(chilitags PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include/chilitags>
+)
+
+target_compile_definitions(chilitags_static PUBLIC
+    -DCHILITAGS_STATIC_DEFINE
+)
+target_include_directories(chilitags_static PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include/chilitags>
+)
+
 target_link_libraries(chilitags ${OpenCV_LIBS})
 target_link_libraries(chilitags_static ${OpenCV_LIBS})
 
@@ -40,6 +59,7 @@ if(WITH_PTHREADS AND NOT DEFINED ANDROID) #Android pthreads don't require -lpthr
 endif()
 
 install (TARGETS chilitags chilitags_static
+    RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
 )
@@ -55,6 +75,7 @@ file(GLOB_RECURSE chilitags_headers ../include/*)
 
 install(FILES
     ${chilitags_headers}
+    ${PROJECT_BINARY_DIR}/chilitags_export.hpp
     DESTINATION include/chilitags
 )
 


### PR DESCRIPTION
export Chilitags class to allow usage as windows dll